### PR TITLE
Enable some SHM tests

### DIFF
--- a/occlum/blocklist/shm_test
+++ b/occlum/blocklist/shm_test
@@ -4,24 +4,17 @@ ShmTest.ShmStat
 
 ShmDeathTest.ReadonlySegment
 ShmDeathTest.SegmentNotAccessibleAfterDetach
+
 ShmTest.AttachDetach
 ShmTest.LookupByKey
 ShmTest.DetachedSegmentsPersist
-ShmTest.MultipleDetachFails
-ShmTest.IpcStat
 ShmTest.IpcInfo
 ShmTest.ShmInfo
 ShmTest.ShmCtlSet
-ShmTest.RemovedSegmentsAreMarkedDeleted
 ShmTest.RemovedSegmentsAreDestroyed
 ShmTest.AllowsAttachToRemovedSegmentWithRefs
-ShmTest.RemovedSegmentsAreNotDiscoverable
 ShmTest.RequestingSegmentSmallerThanSHMMINFails
 ShmTest.RequestingSegmentLargerThanSHMMAXFails
-ShmTest.RequestingUnalignedSizeSucceeds
-ShmTest.RequestingDuplicateCreationFails
-ShmTest.NonExistentSegmentsAreNotFound
 ShmTest.SegmentsSizeFixedOnCreation
 ShmTest.PartialUnmap
-ShmTest.GracefullyFailOnZeroLenSegmentCreation
 ShmTest.NoDestructionOfAttachedSegmentWithMultipleRmid


### PR DESCRIPTION
Occlum will support System V shared memory (See [issue page](https://github.com/occlum/occlum/issues/863) for details). We need to enable some test in gvisor syscall tests to check its correctness.
