### PR TITLE
Fix ZLIB version bug

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,6 +107,17 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "zlib",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = [
+        "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
+        "https://zlib.net/zlib-1.2.11.tar.gz",
+    ],
+)
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 rules_proto_dependencies()


### PR DESCRIPTION
The protobuf depends on zlib-1.2.11.tar.gz, but the url https://zlib.net/zlib-1.2.11.tar.gz is moved (also mentioned in other [issue](https://github.com/madler/zlib/issues/649)). It causes build failed. This PR fixes such issue by using the new url.