### PR TITLE
Remove test for TCP_MAXSEG

### DIFF
--- a/occlum/blocklist/tcp_socket_test
+++ b/occlum/blocklist/tcp_socket_test
@@ -44,3 +44,5 @@ AllInetTests/SimpleTcpSocketTest.SetSocketAttachDetachFilter/0
 AllInetTests/SimpleTcpSocketTest.SetSocketAttachDetachFilter/1
 AllInetTests/TcpSocketTest.MsgTrunc/0
 AllInetTests/TcpSocketTest.MsgTruncWithCtrunc/0
+AllInetTests/SimpleTcpSocketTest.SetMaxSeg/0
+AllInetTests/SimpleTcpSocketTest.SetMaxSeg/1


### PR DESCRIPTION
The behavior defined in `tcp_socket.cc:1266` has changed which makes the check failed. The related patch can be find here: https://lore.kernel.org/netdev/CANn89iLHO7Cma9kdjVTkAy8Z3QvdG-8U4=ob=TSofA5nojWV+w@mail.gmail.com/T/

